### PR TITLE
Emergency shutdown support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -274,8 +274,3 @@ Now you can launch the test suite:
 
 Currently uses an auto-scaling group, rather than a launch configuration. I'd
 like to port it over to use the newer launch configurations instead.
-
-Doesn't deal with spot instance forced termination elegantly. The shutdown
-endpoint needs to be monitored by a cron job, which can then notify players on
-the server. Once it's down that, it can shut down the server, perform an
-immediate backup, and push that backup to S3.

--- a/ansible/minecraft.yml
+++ b/ansible/minecraft.yml
@@ -22,6 +22,7 @@
     - awscli
     - openjdk-8-jre-headless
     - python-pip
+    - jq
 
   - name: "Create minecraft root directory"
     become: true

--- a/ansible/minecraft.yml
+++ b/ansible/minecraft.yml
@@ -77,13 +77,13 @@
       minute: "*/5"
       job: "/minecraft/mining-camp/utilities/prospector.py backup"
 
-  - name: "Add emergency shutdown script to crontab"
-    cron:
-      name: "spot instance shutdown monitor"
-      job: "/minecraft/mining-camp/utilities/shutdown.sh"
+  - name: "Start emergency shutdown monitoring script in the background"
+    shell: |
+      /minecraft/mining-camp/utilities/shutdown.sh /minecraft/{{server_name}} &
 
   - name: "Fetch most recent backup from S3 and install it"
-    shell: /minecraft/mining-camp/utilities/prospector.py fetch
+    shell: |
+      /minecraft/mining-camp/utilities/prospector.py fetch
 
   - name: "Start server bootstrap script"
     shell: |

--- a/utilities/bootstrap.sh
+++ b/utilities/bootstrap.sh
@@ -2,7 +2,7 @@
 #
 # Bootstraps the minecraft server into a tmux session for easy access
 #
-# ./bootstrap server_path
+# ./bootstrap.sh server_path
 
 if [ $# -eq 0 ]; then
     echo "First parameter should be the minecraft server root directory"

--- a/utilities/prospector.py
+++ b/utilities/prospector.py
@@ -109,8 +109,8 @@ class Prospector(object):
                         if d != self.world_name:
                             del dirs[i]
 
-                # Check each file to determine whether it matches our Aroma backup
-                # naming convention.
+                # Check each file to determine whether it matches one of our
+                # known backup formats.
                 for f in files:
                     # Check the filename against our known backup formats
                     result = None
@@ -170,7 +170,8 @@ class Prospector(object):
 
         # Strip the suffix off tmp_path, because `shutil.make_archive` adds its
         # own when it creates the file.
-        shutil.make_archive(tmp_path[:-4], 'zip', '/minecraft', self.world_name)
+        base_path = os.path.join(self.server_root_dir, self.server_name)
+        shutil.make_archive(tmp_path[:-4], 'zip', base_path, self.world_name)
 
         # Create a key for the archive in S3 and upload it
         self.push_most_recent_backup(zipfile=tmp_path)
@@ -235,9 +236,10 @@ def main():
         description="Utilities for interacting with an S3 bucket storing " \
                     "Minecraft servers and backups.")
     parser.add_argument('action', choices=(FETCH, BACKUP, BACKUP_CURRENT),
-        help="The action to take: fetch a backup from S3 and install it, " \
-             "backup the most recent Aroma backup to S3, or back up the " \
-             "current server state to S3 (server should be off).")
+        help="The action to take: 'fetch' gets the most recent backup from " \
+             "S3 and installs it, 'backup' pushes the most recent backup to " \
+             "S3, and 'backup_current' creates a fresh backup from the " \
+             "current world directory and pushes it (server should be off).")
     parser.add_argument('--cfg', nargs=1, default=['/minecraft/prospector.cfg'],
         help="Config file to read settings from.")
     parser.add_argument('--log', nargs=1, default=['/minecraft/prospector.log'],

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# ./shutdown.sh server_path
+#
+# Every 5 seconds, checks whether the instance is going to be shut down or
+# terminated soon. If the instance is to be stopped or terminated, does the
+# following:
+#
+# 1. Notifies players via a server broadcast.
+# 2. Shuts the server down.
+# 3. Runs a backup on the server world and pushes it to S3.
+#
+# NOTE: This assumes that the "minecraft" tmux session is available and the
+# first pane is the one the minecraft server and console is running in.
+
+# Deal with script arguments
+SERVER_ROOT=${1:-/minecraft}
+
+TMUX_SESSION=minecraft
+TMUX_PANE=${TMUX_SESSION}:0.0
+
+# Number of seconds to wait before shutting server down
+DELAY=30
+
+
+# minecraft_cmd <string>
+#
+# Connect to the "minecraft" tmux session and send commands to the
+# first pane, presumably the one the server is running in.
+minecraft_cmd () {
+    tmux send-keys -t "${TMUX_PANE}" "$1" C-m
+}
+
+# minecraft_msg <text> [<color>]
+#
+# Connects to the "minecraft" tmux session and sends a message containing
+# <text> marked for all users. <color> is a string, defaulting to "gold" if not
+# set. See supported colors here:
+# https://minecraft.gamepedia.com/Formatting_codes
+minecraft_msg () {
+    action="${1}"
+    color="${2:-gold}"
+
+    # Sends a json-formatted message to all players
+    minecraft_cmd "/tellraw @a {\"text\": \"$action\", \"color\": \"$color\"}"
+}
+
+
+while [ true ]; do
+    # This fetches only the headers, mutes all of curl's output, and prints
+    # only the HTTP status code returned. If this code is anything other than a
+    # 404, investigate further.
+    status_code=`curl -I -s -o /dev/null -w '%{http_code}' http://169.254.169.254/latest/meta-data/spot/instance-action`
+
+    if [ "$status_code" != "404" ]; then
+        # Determine what action is being taken on the instance
+        # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html
+        # for more details on this.
+        resp=`curl http://169.254.169.254/latest/meta-data/spot/instance-action`
+        # resp='{"action": "stop", "time": "2017-09-18T08:22:00Z"}'
+
+        # Parse the action and the time out of the message
+        action=`echo $resp | jq -r '.action'`
+        time=`echo $resp | jq -r '.time'`
+
+        minecraft_msg "[AWS] Warning! Spot instance terminating!" "red"
+        minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
+
+        # Brief delay, allowing players to finish up before shutting down
+        sleep $DELAY
+
+        # Shut the server down, and wait for it to exit
+        minecraft_cmd "stop"
+        pid=`pgrep -f ServerStart.sh`
+        while ps -p $pid; do
+            sleep 1
+        done
+
+        # Create and push a backup to S3
+        $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+
+        break
+    fi
+
+    sleep 5
+done

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -72,7 +72,7 @@ while [ true ]; do
         # Shut the server down, and wait for it to exit
         minecraft_cmd "stop"
         pid=`pgrep -f ServerStart.sh`
-        while ps -p $pid; do
+        while ps -p $pid > /dev/null; do
             sleep 1
         done
 


### PR DESCRIPTION
Adds the new emergency shutdown script, which monitors the spot instance's actions endpoint for news. If a stop, terminate or hiberate is seen, it notifies the players, waits for a brief period to allow players to finish up, shuts down the server, and finally creates pushes a fresh backup to S3.