### PR TITLE
Shutdown Support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -108,8 +108,7 @@ Then, from the root directory of your modified `mining-camp` checkout run:
 ```
 
 Once this has successfully completed, your AWS configuration is complete.
-Unless you change terraform settings or need to shutdown your server you won't
-need to run this again.
+Unless you change your AWS configuration, you won't need to run this again.
 
 ==== Ansible
 
@@ -129,6 +128,10 @@ More details on creating this archive are below.
 
 Update `ansible/files/prospector.cfg` with the same settings, as well as with
 the _world_name_ you'll be using.
+
+Lastly, update `ansible/ec2.ini`'s `regions` entry with the AWS region you're
+using. You can set this to _all_, but the dynamic EC2 entry script will take
+longer.
 
 ==== Minecraft Server Archive
 
@@ -196,63 +199,32 @@ $ aws s3 cp daftcyborg-server-12-20-2017.tgz s3://josh-minecraft/daftcyborg/
 
 === Server Launch & Provision
 
-Up until now, everything in EC2 is created but no instances are running. To
-launch an instance, open `terraform/main.tf` and edit the _minecraft_
-`aws_autoscaling_group`'s `desired_capacity` from _0_ to _1_. Then re-run
-terraform, like:
-
-```
-./terraform apply terraform/
-```
-
-Now you have an instance running, but it hasn't been set up to run our server.
 Jump to the `ansible` directory, and run the playbook to configure the instance
 and launch the minecraft server:
 
 ```
 cd ansible
-ansible-playbook -i ec2.py --private-key=~/.ssh/aws -u ubuntu -c ssh minecraft.yml
+ansible-playbook -i ec2.py --private-key=~/.ssh/aws -u ubuntu -c ssh start.yml
 ```
 
-The `ec2.py` inventory file should automatically pick up your new instance
-after one or two attempts. On my setup, the Paramiko Python library Ansible
-uses by default ran into errors when attempting to gather facts from the server,
-so I use `-c ssh` instead.
+The `ec2.py` inventory file should automatically pick up your new instance.
 
-Sometimes the NVMe mount will succeed, but the subsequent folder creation will
-fail due to the mount not being available fast enough. If this occurs, simply
-re-run.
+NOTE: On my setup, the Paramiko library Ansible uses by default ran into errors
+when attempting to gather facts from the server, so I had to use `-c ssh`
+instead.
 
 === Server Shutdown
 
-Reverting the change made when launching your server, edit `terraform/main.tf`
-and change `desired_capacity` from _1_ back to _0_. Applying your terraform
-changes will cause the instance to start shutting down, like:
+Shutting down your server is just as easy as starting it:
 
 ```
-./terraform apply terraform/
+cd ansible
+ansible-playbook -i ec2.py --private-key=~/.ssh/aws -u ubuntu -c ssh stop.yml
 ```
 
-Now your instance is gone, but your most recent backups are present in S3,
-waiting for the next launch. Note that if you're planning on shutting it down
-permanently, you'll want to delete the elastic IP and any backups, or else
-you'll continue to incur AWS charges.
-
-== Troubleshooting
-
-If you want to connect to your instance directly, use the key-pair you set up
-initially to SSH into the instance:
-
-```
-ssh -i ~/.ssh/aws ubuntu@<elastic_ip>
-```
-
-Once you're on the box, you can attach to the tmux session the server has been
-started in:
-
-```
-tmux attach-session -t minecraft
-```
+When this playbook finishes, your instance will be gone, but the state of the
+server will have been preserved and pushed to S3, ready for the next time you
+launch it.
 
 == Tests
 
@@ -274,3 +246,6 @@ Now you can launch the test suite:
 
 Currently uses an auto-scaling group, rather than a launch configuration. I'd
 like to port it over to use the newer launch configurations instead.
+
+Create a configuration script that can take user input and populate the
+configuration files as needed. This would make this so painless!

--- a/README.adoc
+++ b/README.adoc
@@ -207,7 +207,8 @@ cd ansible
 ansible-playbook -i ec2.py --private-key=~/.ssh/aws -u ubuntu -c ssh start.yml
 ```
 
-The `ec2.py` inventory file should automatically pick up your new instance.
+You may be prompted when attempting to connect to your host. If you'd like to
+skip this check, set `ANSIBLE_HOST_KEY_CHECKING=false` for these commands.
 
 NOTE: On my setup, the Paramiko library Ansible uses by default ran into errors
 when attempting to gather facts from the server, so I had to use `-c ssh`

--- a/ansible/ec2.ini
+++ b/ansible/ec2.ini
@@ -114,7 +114,7 @@ cache_path = ~/.ansible/tmp
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 # To disable the cache, set this value to 0
-cache_max_age = 300
+cache_max_age = 0
 
 # Organize groups into a nested/hierarchy instead of a flat namespace.
 nested_groups = False

--- a/ansible/start.yml
+++ b/ansible/start.yml
@@ -1,16 +1,30 @@
+- name: "Set ASG size to 1"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+  - ec2_asg:
+      name: "minecraft"
+      desired_capacity: 1
+      region: "{{aws_region}}"
+
+  # Since the above task changes the host set, refresh the inventory before
+  # continuing
+  - meta: refresh_inventory
+
+# Fact gathering doesn't work if Python isn't available on the hosts, so we do
+# this and the prior task first
 - name: "Pre-fact-gathering Setup"
   hosts: all
   gather_facts: false
 
   tasks:
-  - name: "Install Python (required for fact gathering)"
+  - name: "Install Python on hosts"
     become: true
     raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
 
-- name: "Installation"
+- name: "Installation & Launch"
   hosts: all
-  tags:
-  - deploy
 
   tasks:
   - name: "Install prerequisites"
@@ -32,13 +46,14 @@
       group: ubuntu
       state: directory
 
+  # Not portable
   - name: "Mount NVMe device to minecraft directory"
     become: true
     become_user: root
     shell: |
         mkfs.ext4 /dev/nvme0n1
         mount -t ext4 /dev/nvme0n1 /minecraft
-    ignore_errors: true
+        chown ubuntu:ubuntu /minecraft
 
   - name: "Clone git repo into minecraft directory"
     git:
@@ -80,9 +95,9 @@
 
   - name: "Start emergency shutdown monitoring script in the background"
     # In order to run a background process, we detach inputs and outputs and
-    # use nohup
+    # use nohup. This runs shutdown.sh in its daemon mode.
     shell: |
-      nohup /minecraft/mining-camp/utilities/shutdown.sh /minecraft/{{server_name}} </dev/null >/dev/null 2>&1 &
+      nohup /minecraft/mining-camp/utilities/shutdown.sh /minecraft </dev/null >/dev/null 2>&1 &
 
   - name: "Fetch most recent backup from S3 and install it"
     shell: |
@@ -94,3 +109,4 @@
 
   - name: "Assign elastic ip"
     local_action: shell aws ec2 associate-address --region {{aws_region}} --instance-id {{ec2_id}} --allocation-id {{minecraft_eip_alloc_id}}
+    ignore_errors: true

--- a/ansible/stop.yml
+++ b/ansible/stop.yml
@@ -1,0 +1,19 @@
+# Ansible playbook for shutting down minecraft server and terminating the spot
+# instance.
+
+- name: "Shutdown"
+  hosts: all
+
+  tasks:
+  - name: "Shutdown server and push backup to S3"
+    shell: |
+        /minecraft/mining-camp/utilities/shutdown.sh /minecraft
+
+- name: "Set ASG size to 0"
+  hosts: localhost
+
+  tasks:
+  - ec2_asg:
+      name: "minecraft"
+      desired_capacity: 0
+      region: "{{aws_region}}"

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -2,13 +2,24 @@
 #
 # ./shutdown.sh server_path
 #
-# Every 5 seconds, checks whether the instance is going to be shut down or
-# terminated soon. If the instance is to be stopped or terminated, does the
-# following:
+# If the script is run in the background (&), runs in Daemon mode, otherwise
+# runs in Active mode.
 #
-# 1. Notifies players via a server broadcast.
+# "Daemon" Mode
+#
+# Every 5 seconds, checks whether the instance is going to be shut down or
+# terminated soon. If the instance is to be stopped or terminated, performs the
+# same steps as Active mode.
+#
+# "Active" Mode
+#
+# Immediately does the following
+#
+# 1. Notifies players via a server broadcast that the server will be shut down
+#    after a brief delay.
 # 2. Shuts the server down.
 # 3. Runs a backup on the server world and pushes it to S3.
+#
 #
 # NOTE: This assumes that the "minecraft" tmux session is available and the
 # first pane is the one the minecraft server and console is running in.
@@ -45,42 +56,74 @@ minecraft_msg () {
     minecraft_cmd "/tellraw @a {\"text\": \"$action\", \"color\": \"$color\"}"
 }
 
+# shutdown_server
+#
+# Sends a shutdown command to the tmux pane the server in running in, then
+# waits for it to exit.
+shutdown_server () {
+    minecraft_cmd "stop"
+    pid=`pgrep -f ServerStart.sh`
+    while ps -p $pid > /dev/null; do
+        sleep 1
+    done
+}
 
-while [ true ]; do
-    # This fetches only the headers, mutes all of curl's output, and prints
-    # only the HTTP status code returned. If this code is anything other than a
-    # 404, investigate further.
-    status_code=`curl -I -s -o /dev/null -w '%{http_code}' http://169.254.169.254/latest/meta-data/spot/instance-action`
 
-    if [ "$status_code" != "404" ]; then
-        # Determine what action is being taken on the instance
-        # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html
-        # for more details on this.
-        resp=`curl http://169.254.169.254/latest/meta-data/spot/instance-action`
-        # resp='{"action": "stop", "time": "2017-09-18T08:22:00Z"}'
+# Check if the script is running in the foreground or in the background.
+# - Background: Run in daemon mode, checking for emergency shutdown action
+#     every few seconds.
+# - Foreground: Run in active mode, immediately shutting down and backing up
+#     the server.
 
-        # Parse the action and the time out of the message
-        action=`echo $resp | jq -r '.action'`
-        time=`echo $resp | jq -r '.time'`
+# "+" in the ps output indicates the process is running in the foreground
+mypid=$$
+if [[ "$(ps -o stat= -p $mypid)" =~ \+ ]]; then
+    # Foreground, script mode
+    echo "Notifying users"
+    minecraft_msg "[AWS] Warning! Server is shutting down!" "red"
+    minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
 
-        minecraft_msg "[AWS] Warning! Spot instance terminating!" "red"
-        minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
+    # Brief delay, allowing players to finish up before shutting down
+    echo "Shutting down server in $DELAY seconds"
+    sleep $DELAY
+    shutdown_server
 
-        # Brief delay, allowing players to finish up before shutting down
-        sleep $DELAY
+    echo "Creating and pushing backup to S3"
+    $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+else
+    # Background, daemon mode
+    echo "Running in background mode!"
 
-        # Shut the server down, and wait for it to exit
-        minecraft_cmd "stop"
-        pid=`pgrep -f ServerStart.sh`
-        while ps -p $pid > /dev/null; do
-            sleep 1
-        done
+    while [ true ]; do
+        # This fetches only the headers, mutes all of curl's output, and prints
+        # only the HTTP status code returned. If this code is anything other than a
+        # 404, investigate further.
+        status_code=`curl -I -s -o /dev/null -w '%{http_code}' http://169.254.169.254/latest/meta-data/spot/instance-action`
 
-        # Create and push a backup to S3
-        $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+        if [ "$status_code" != "404" ]; then
+            # Determine what action is being taken on the instance
+            # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html
+            # for more details on this.
+            resp=`curl http://169.254.169.254/latest/meta-data/spot/instance-action`
+            # resp='{"action": "stop", "time": "2017-09-18T08:22:00Z"}'
 
-        break
-    fi
+            # Parse the action and the time out of the message
+            action=`echo $resp | jq -r '.action'`
+            time=`echo $resp | jq -r '.time'`
 
-    sleep 5
-done
+            minecraft_msg "[AWS] Warning! Spot instance terminating!" "red"
+            minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
+
+            # Brief delay, allowing players to finish up before shutting down
+            sleep $DELAY
+            shutdown_server
+
+            # Create and push a backup to S3
+            $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+
+            break
+        fi
+
+        sleep 5
+    done
+fi

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# ./shutdown.sh server_path
+# ./shutdown.sh minecraft_root
 #
-# If the script is run in the background (&), runs in Daemon mode, otherwise
-# runs in Active mode.
+# `minecraft_root` should be the base directory everything minecraft-related is
+# installed to, usually /minecraft. This script can be run in two different
+# modes, depending on whether it is backgrounded (&) or not.
 #
 # "Daemon" Mode
 #
@@ -25,7 +26,7 @@
 # first pane is the one the minecraft server and console is running in.
 
 # Deal with script arguments
-SERVER_ROOT=${1:-/minecraft}
+MINECRAFT_ROOT=${1:-/minecraft}
 
 TMUX_SESSION=minecraft
 TMUX_PANE=${TMUX_SESSION}:0.0
@@ -89,7 +90,7 @@ if [[ "$(ps -o stat= -p $mypid)" =~ \+ ]]; then
     shutdown_server
 
     echo "Creating and pushing backup to S3"
-    $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+    $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup_current
 else
     # Background, daemon mode
     echo "Running in background mode!"
@@ -119,7 +120,7 @@ else
             shutdown_server
 
             # Create and push a backup to S3
-            $SERVER_ROOT/mining-camp/utilities/prospector.py backup_current
+            $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup_current
 
             break
         fi


### PR DESCRIPTION
Adds support for archiving and shutting down the server, then killing the active spot instance.

Changes:
* `minecraft.yml` is now `start.yml`. Shutdown playbook is `stop.yml`.
* Playbooks now adjust auto-scaling group size, which means that terraform no longer needs to be run every time a spot instance needs to be started or stopped.
* README has been updated with the above playbooks, and the terraform mentions have been drastically reduced.

Fixes:
* NVMe drive now should correctly mount and be accessible by the `ubuntu` user when attempting to clone the github repo.