### PR TITLE
Better Backups

### DIFF
--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -101,11 +101,11 @@
       src: "files/server.properties"
       dest: "{{minecraft_dir}}/{{server_name}}/server.properties"
 
-  - name: "Add backup script to crontab"
+  - name: "Add periodic backup script to crontab"
     cron:
-      name: "minecraft backup monitor"
-      minute: "*/5"
-      job: "{{minecraft_dir}}/mining-camp/utilities/prospector.py backup"
+      name: "Backup creation"
+      minute: "*/30"
+      job: "{{minecraft_dir}}/mining-camp/utilities/backup.sh {{minecraft_dir}}"
 
   - name: "Start emergency shutdown monitoring script in the background"
     # In order to run a background process, we detach inputs and outputs and

--- a/utilities/backup.sh
+++ b/utilities/backup.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Dumps and pushes a backup of the current minecraft world. The actual backup
+# and push to S3 is delegated to prospector, this script takes care of:
+#
+# 1. Notifying users that a dump is happening (a brief freeze may occur).
+# 2. Suspending all writes to disk.
+# 3. Performing a full, manual dump to disk.
+# 4. Launching prospector to create and push the backup.
+# 5. Resuming normal operates, including writes to disk.
+#
+# ./backup.sh [minecraft_root]
+#
+# `minecraft_root` should be the base directory everything minecraft-related is
+# installed to, usually /minecraft.
+
+
+# Deal with script arguments
+MINECRAFT_ROOT=${1:-/minecraft}
+
+TMUX_SESSION=minecraft
+TMUX_PANE=${TMUX_SESSION}:0.0
+
+
+# TODO: Helper functions are duplicated from shutdown.sh
+
+# minecraft_cmd <string>
+#
+# Connect to the "minecraft" tmux session and send commands to the
+# first pane, presumably the one the server is running in.
+minecraft_cmd () {
+    tmux send-keys -t "${TMUX_PANE}" "$1" C-m
+}
+
+# minecraft_msg <text> [<color>]
+#
+# Connects to the "minecraft" tmux session and sends a message containing
+# <text> marked for all users. <color> is a string, defaulting to "gold" if not
+# set. See supported colors here:
+# https://minecraft.gamepedia.com/Formatting_codes
+minecraft_msg () {
+    action="${1}"
+    color="${2:-gold}"
+
+    # Sends a json-formatted message to all players
+    minecraft_cmd "/tellraw @a {\"text\": \"$action\", \"color\": \"$color\"}"
+}
+
+echo "Starting backup at `date`"
+minecraft_msg "[MINING-CAMP] Backing up world..."
+
+# Make sure any half-finished commands are cleared out, if someone was manually
+# playing with the server
+minecraft_cmd C-m
+
+# Turn off automatic saving, and flush world state to disk
+minecraft_cmd "/save-off"
+minecraft_cmd "/save-all flush"
+
+# Sleep while flushing
+sleep 15
+
+# Delegate backup create and transfer to prospector
+$MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
+
+# Log and notify server users
+if [ $? -eq 0 ]; then
+    msg="Backup completed successfully at `date`!"
+    echo "${msg}"
+else
+    msg="Backup failed at `date`!"
+    echo "${msg}" >&2
+fi
+minecraft_msg "[MINING-CAMP] ${msg}"
+
+# Resume normal server operations even if the backup failed
+minecraft_cmd "/save-on"

--- a/utilities/prospector.py
+++ b/utilities/prospector.py
@@ -101,9 +101,11 @@ class Prospector(object):
         # If a key isn't returned, there's nothing to do
         if key:
             tmp_path = os.path.join('/tmp', os.path.basename(key))
-            logger.info("Downloading backup from s3://{}/{} to {}".format(self.s3_bucket,
-                                                                          key,
-                                                                          tmp_path))
+            logger.info("Downloading backup from s3://{}/{} to {}".format(
+                self.s3_bucket,
+                key,
+                tmp_path
+            ))
 
             self.client.download_file(self.s3_bucket, key, tmp_path)
 

--- a/utilities/tests/requirements.txt
+++ b/utilities/tests/requirements.txt
@@ -1,2 +1,3 @@
+freezegun==0.3.15
 moto==1.3.14
 sure==1.4.11

--- a/utilities/tests/test_prospector.py
+++ b/utilities/tests/test_prospector.py
@@ -22,15 +22,15 @@ S3_DATE_FMT = '%Y%m%dT%H%M%S'
 class TestProspector(TestCase):
 
     def setUp(self):
-      # Mock S3 is used for all tests
+        # mock S3 is used for all tests
         self.mock = mock_s3()
         self.mock.start()
 
-        # Create a connection to our mock S3 and populate it
+        # create a connection to our mock S3 and populate it
         self.s3_client = boto3.client('s3', region_name='us-east-1')
         self.s3_client.create_bucket(Bucket='my_bucket')
 
-        # Make a temporary directory to simulate the server root
+        # make a temporary directory to work in, so it can be cleaned up later
         self.temp_dir = tempfile.mkdtemp()
 
         self.cfg = {
@@ -40,17 +40,28 @@ class TestProspector(TestCase):
             's3_bucket': 'my_bucket'
         }
 
-        # Create a world directory
+        # create mock server and world directories
         self.server_path = os.path.join(self.temp_dir, self.cfg['server_name'])
         self.world_path = os.path.join(self.server_path, self.cfg['world_name'])
         os.makedirs(self.world_path)
 
-        # and write a number of files to the base
+        self.populate_mock_server()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+        self.mock.stop()
+
+    def populate_mock_server(self):
+        """
+        Populates a mock server directory with files, including a nested
+        structure in the world subdirectory.
+        """
+        # write a number of files to the server directory
         for i in range(0, 4):
             with open(os.path.join(self.server_path, str(i)), 'w') as f:
                 f.write(os.urandom(33))
 
-        # and the world directory itself, in subfolders
+        # and to the world directory, nested in subfolders
         for f in range(0, 3):
             folder_path = os.path.join(self.world_path, 'folder-' + str(f))
             os.mkdir(folder_path)
@@ -59,25 +70,13 @@ class TestProspector(TestCase):
                 with open(os.path.join(folder_path, str(i)), 'w') as f:
                     f.write(os.urandom(100))
 
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir)
-        self.mock.stop()
-
-    def test_properties(self):
-        # Given a Prospector created with the base config
-        p = Prospector(**self.cfg)
-
-        # It should be able to give us the s3 prefix and the local backup directory
-        p.s3_backup_prefix.should.equal('my_server/backups/my_world')
-
     def checksum_walk(self, path):
         """
         Given a `path`, returns a dictionary of `relative_path` => MD5
         `checksum` pairs. `relative_path` is created by stripping `path` off
         all absolute paths.
         """
-        # Traverse our original world directory, gathering paths and
-        # checksums
+        # traverse the original world directory, gathering paths and checksums
         checksums = {}
         for folder, _, files in os.walk(path):
             relative_folder = folder.replace(path, '')
@@ -88,12 +87,22 @@ class TestProspector(TestCase):
                     checksums[relative_path] = hashlib.md5(f.read()).hexdigest()
         return checksums
 
-    def test_backup_creation(self):
-        # Given a Prospector created with the base config
+    def test_properties(self):
+        # given a Prospector created with the base config
         p = Prospector(**self.cfg)
 
-        # temporary directory we can extract to
-        extraction_dir = tempfile.mkdtemp()
+        # it should be able to give us the s3 prefix and the local backup directory
+        p.s3_backup_prefix.should.equal('my_server/backups/my_world')
+        p.server_path.should.equal(os.path.join(self.temp_dir, 'my_server'))
+        p.world_path.should.equal(os.path.join(self.temp_dir, 'my_server', 'my_world'))
+
+    def test_backup_creation(self):
+        # given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # and a temporary directory to extract archives to
+        extraction_dir = os.path.join(self.temp_dir, 'extraction')
+        os.mkdir(extraction_dir)
 
         backup_path = p.create_current_backup()
         backup_dir = os.path.dirname(backup_path)
@@ -106,14 +115,14 @@ class TestProspector(TestCase):
                 # archive
                 len(members_info).should.equal(21)
 
-                # and all filenames should start with the world name,
-                # indicating only world-related files were packed
+                # all filenames should start with the world name, indicating
+                # only world-related files were packed
                 for zinfo in members_info:
                     zinfo.filename.startswith(self.cfg['world_name']).should.be.true
 
                 z.extractall(extraction_dir)
 
-            # Compare the paths and checksums of the original world directory
+            # compare the paths and checksums of the original world directory
             # with the one just extracted
             extracted_world_path = os.path.join(extraction_dir, self.cfg['world_name'])
             extracted_checksums = self.checksum_walk(extracted_world_path)
@@ -121,30 +130,28 @@ class TestProspector(TestCase):
 
             extracted_checksums.should.equal(original_checksums)
         finally:
-            # remove temporary directories created
-            rmtree(extraction_dir)
             rmtree(os.path.dirname(backup_path))
 
     def test_s3_backup_key(self):
         # Given a Prospector created with the base config
         p = Prospector(**self.cfg)
 
-        # when we generate a backup key from a certain datetime
+        # generate a backup key from a certain datetime
         dt = datetime(2020, 3, 4, 12, 35, 40)
         key = p.s3_backup_key(dt)
 
         # it should be formatted as expected
         key.should.equal('my_server/backups/my_world-20200304T123540.zip')
 
-        # and when converted backwards to a datetime
+        # and, when converted backwards to a datetime
         key_dt = p.backup_time_from_key(key)
         
         # it should equal the original datetime
         key_dt.should.equal(dt)
 
     @freeze_time("2020-03-04 02:34:56")
-    def test_current_backup(self): 
-        # Given a Prospector created with the base config
+    def test_push_current_backup(self): 
+        # given a Prospector created with the base config
         p = Prospector(**self.cfg)
 
         # there should initially be no backups present in S3
@@ -162,3 +169,108 @@ class TestProspector(TestCase):
         backup_meta = response['Contents'][0]
         backup_time = p.backup_time_from_key(backup_meta['Key'])
         backup_time.should.equal(datetime(2020, 3, 4, 2, 34, 56))
+
+    def test_upload_backup(self):
+        # given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # create a dummy backup archive
+        mock_archive = os.path.join(self.temp_dir, 'backup.zip')
+        with open(mock_archive, 'w') as f:
+            f.write(os.urandom(100))
+
+        # upload some backups
+        time = datetime(2020, 5, 23, 11, 45)
+        backup_times = []
+        for i in range(0, 5):
+            backup_times.append(time)
+            
+            with freeze_time(time):
+                p.upload_backup(mock_archive)
+            
+            # shift the clock ahead for the next backup
+            time += timedelta(hours=13)
+
+        # now, looking in S3, all backups should be present
+        response = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
+        response['KeyCount'].should.equal(len(backup_times))
+
+        # and the tags for each backup should be correct, with the newest
+        # backup tagged as `new`, and the rest tagged as `old`, intended for
+        # use by the lifecycle rules in place on the bucket.
+        for item in response['Contents']:
+            response = self.s3_client.get_object_tagging(
+                Bucket=self.cfg['s3_bucket'],
+                Key=item['Key']
+            )
+
+            # convert the tags into an easier-to-use dictionary format
+            tags = {t['Key']: t['Value'] for t in response['TagSet']}
+
+            # check them against the backup times
+            bt = p.backup_time_from_key(item['Key']) 
+            if bt in backup_times[:-1]:
+                tags.should.equal({'backup': 'old'})
+            elif bt == backup_times[-1]:
+                tags.should.equal({'backup': 'new'})
+            else:
+                raise Exception('Unexpected backup key \'{}\''.format(item['Key']))
+
+    def test_get_most_recent_backup_key(self):
+        # given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # create a dummy backup archive
+        mock_archive = os.path.join(self.temp_dir, 'backup.zip')
+        with open(mock_archive, 'w') as f:
+            f.write(os.urandom(100))
+
+        # upload a few backups
+        time = datetime(2020, 5, 23, 11, 45)
+        backup_times = []
+        for i in range(0, 5):
+            backup_times.append(time)
+            
+            with freeze_time(time):
+                p.upload_backup(mock_archive)
+            
+            # shift the clock ahead for the next backup
+            time += timedelta(hours=13)
+
+        # if the most recent one is requested, the date should be that of
+        # the last backup made
+        backup_key = p.get_most_recent_backup_key()
+        backup_key.should.equal('my_server/backups/my_world-20200525T154500.zip')
+
+    def test_fetch_most_recent_backup(self):
+        # given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # create and upload some backups, with different world contents
+        time = datetime(2020, 5, 23, 11, 45)
+        backup_times = []
+        for i in range(0, 5):
+            backup_times.append(time)
+
+            # destroy and recreate so the contents vary
+            shutil.rmtree(self.server_path)
+            os.makedirs(self.world_path)
+
+            self.populate_mock_server()
+            
+            with freeze_time(time):
+                p.push_current_backup()
+
+            time += timedelta(days=27)
+
+        # get the checksum of the current world, then blow it awayd
+        current_world_checksum = self.checksum_walk(self.world_path)
+        shutil.rmtree(self.world_path)
+
+        # fetch the latest backup from S3
+        p.fetch_most_recent_backup()
+        backup_world_checksum = self.checksum_walk(self.world_path)
+
+        # all checksums should match
+        len(current_world_checksum).should.equal(21)
+        current_world_checksum.should.equal(backup_world_checksum)

--- a/utilities/tests/test_prospector.py
+++ b/utilities/tests/test_prospector.py
@@ -1,19 +1,21 @@
+import hashlib
 import os
 import shutil
 import sys
 import tempfile
 from datetime import datetime, timedelta
 from unittest import TestCase
+from shutil import rmtree
+from zipfile import ZipFile
 
 import boto3
 import sure
+from freezegun import freeze_time
 from moto import mock_s3
 
 from utilities.prospector import Prospector
 
 
-AROMA_FMT = 'dangerworld-backup-%Y-%m-%d--%H-%M.zip'
-FTB_UTILS_FMT = '%Y-%m-%d-%H-%M-%S.zip'
 S3_DATE_FMT = '%Y%m%dT%H%M%S'
 
 
@@ -38,9 +40,24 @@ class TestProspector(TestCase):
             's3_bucket': 'my_bucket'
         }
 
-        # Create the empty backup directory
-        self.backup_path = os.path.join(self.temp_dir, 'my_server', 'backups')
-        os.makedirs(self.backup_path)
+        # Create a world directory
+        self.server_path = os.path.join(self.temp_dir, self.cfg['server_name'])
+        self.world_path = os.path.join(self.server_path, self.cfg['world_name'])
+        os.makedirs(self.world_path)
+
+        # and write a number of files to the base
+        for i in range(0, 4):
+            with open(os.path.join(self.server_path, str(i)), 'w') as f:
+                f.write(os.urandom(33))
+
+        # and the world directory itself, in subfolders
+        for f in range(0, 3):
+            folder_path = os.path.join(self.world_path, 'folder-' + str(f))
+            os.mkdir(folder_path)
+
+            for i in range(0, 7):
+                with open(os.path.join(folder_path, str(i)), 'w') as f:
+                    f.write(os.urandom(100))
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
@@ -52,107 +69,96 @@ class TestProspector(TestCase):
 
         # It should be able to give us the s3 prefix and the local backup directory
         p.s3_backup_prefix.should.equal('my_server/backups/my_world')
-        p.local_backup_path.should.equal(self.backup_path)
 
-    def test_push_most_recent_backup_no_backups(self):
+    def checksum_walk(self, path):
+        """
+        Given a `path`, returns a dictionary of `relative_path` => MD5
+        `checksum` pairs. `relative_path` is created by stripping `path` off
+        all absolute paths.
+        """
+        # Traverse our original world directory, gathering paths and
+        # checksums
+        checksums = {}
+        for folder, _, files in os.walk(path):
+            relative_folder = folder.replace(path, '')
+            for file_name in files:
+                file_path = os.path.join(folder, file_name)
+                relative_path = os.path.join(relative_folder, file_name)
+                with open(file_path, 'r') as f:
+                    checksums[relative_path] = hashlib.md5(f.read()).hexdigest()
+        return checksums
+
+    def test_backup_creation(self):
         # Given a Prospector created with the base config
         p = Prospector(**self.cfg)
 
-        # and no generated backups
-        # when attempting to push the most recent backup
-        p.push_most_recent_backup()
+        # temporary directory we can extract to
+        extraction_dir = tempfile.mkdtemp()
 
-        # There should be nothing in S3 still, because no backup was available
-        # to push
+        backup_path = p.create_current_backup()
+        backup_dir = os.path.dirname(backup_path)
+
+        try:
+            with ZipFile(backup_path, 'r') as z:
+                members_info = z.infolist()
+
+                # the number of files created should match the count in the
+                # archive
+                len(members_info).should.equal(21)
+
+                # and all filenames should start with the world name,
+                # indicating only world-related files were packed
+                for zinfo in members_info:
+                    zinfo.filename.startswith(self.cfg['world_name']).should.be.true
+
+                z.extractall(extraction_dir)
+
+            # Compare the paths and checksums of the original world directory
+            # with the one just extracted
+            extracted_world_path = os.path.join(extraction_dir, self.cfg['world_name'])
+            extracted_checksums = self.checksum_walk(extracted_world_path)
+            original_checksums = self.checksum_walk(p.world_path)
+
+            extracted_checksums.should.equal(original_checksums)
+        finally:
+            # remove temporary directories created
+            rmtree(extraction_dir)
+            rmtree(os.path.dirname(backup_path))
+
+    def test_s3_backup_key(self):
+        # Given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # when we generate a backup key from a certain datetime
+        dt = datetime(2020, 3, 4, 12, 35, 40)
+        key = p.s3_backup_key(dt)
+
+        # it should be formatted as expected
+        key.should.equal('my_server/backups/my_world-20200304T123540.zip')
+
+        # and when converted backwards to a datetime
+        key_dt = p.backup_time_from_key(key)
+        
+        # it should equal the original datetime
+        key_dt.should.equal(dt)
+
+    @freeze_time("2020-03-04 02:34:56")
+    def test_current_backup(self): 
+        # Given a Prospector created with the base config
+        p = Prospector(**self.cfg)
+
+        # there should initially be no backups present in S3
         response = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
         response['KeyCount'].should.equal(0)
 
-    def test_push_most_recent_aroma_backup(self):
-        # Given a Prospector created with the base config
-        p = Prospector(**self.cfg)
+        # but when we push a current backup
+        p.push_current_backup() 
 
-        # and three Aroma backups:
-        # backups/          OLD
-        old_backup = (datetime.now() - timedelta(minutes=30)).strftime(AROMA_FMT)
-        with open(os.path.join(self.backup_path, old_backup), 'w') as f:
-            f.write('')
-
-        # backups/my_world/     NEW
-        # this should be the backup used; mark the backup time string and
-        # convert it back to a datetime (because Aroma strips off the seconds)
-        backup_time = datetime.now() - timedelta(minutes=15)
-        new_backup = backup_time.strftime(AROMA_FMT)
-        backup_time = datetime.strptime(new_backup, AROMA_FMT)
-
-        world_backup_path = os.path.join(self.backup_path, self.cfg['world_name'])
-        os.makedirs(world_backup_path)
-        with open(os.path.join(world_backup_path, new_backup), 'w') as f:
-            f.write('')
-
-        # backups/not_my_world/ NEWEST
-        # this backup should be ignored, because it's in a backup subdirectory
-        # that isn't the configured world, even though it's the newest backup
-        newest_backup = datetime.now().strftime(AROMA_FMT)
-        other_backup_path = os.path.join(self.backup_path, 'my_other_world')
-        os.makedirs(other_backup_path)
-        with open(os.path.join(other_backup_path, newest_backup), 'w') as f:
-            f.write('')
-
-        # when pushing the most recent backup
-        p.push_most_recent_backup()
-
-        # it should be available in S3
+        # there now should be a backup present in S3
         response = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
         response['KeyCount'].should.equal(1)
 
-        s3_key = 'my_server/backups/my_world-{}.zip'.format(backup_time.strftime(S3_DATE_FMT))
-        response['Contents'][0]['Key'].should.equal(s3_key)
-
-    def test_push_most_recent_backup_ftbutils_backup(self):
-        # Given a Prospector created with the base config
-        p = Prospector(**self.cfg)
-
-        # and two FTB backups
-        old_backup = (datetime.now() - timedelta(minutes=30)).strftime(FTB_UTILS_FMT)
-        with open(os.path.join(self.backup_path, old_backup), 'w') as f:
-            f.write('')
-
-        backup_time = datetime.now()
-        new_backup = backup_time.strftime(FTB_UTILS_FMT)
-        with open(os.path.join(self.backup_path, new_backup), 'w') as f:
-            f.write('')
-
-        # when pushing the most recent backup
-        p.push_most_recent_backup()
-
-        # it should be available in S3
-        response = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
-        response['KeyCount'].should.equal(1)
-
-        s3_key = 'my_server/backups/my_world-{}.zip'.format(backup_time.strftime(S3_DATE_FMT))
-        response['Contents'][0]['Key'].should.equal(s3_key)
-
-    def test_push_most_recent_backup_already_pushed(self):
-        # Given a Prospector created with the base config
-        p = Prospector(**self.cfg)
-
-        # and a backup
-        backup_time = datetime.now()
-        new_backup = backup_time.strftime(FTB_UTILS_FMT)
-        with open(os.path.join(self.backup_path, new_backup), 'w') as f:
-            f.write('')
-
-        # when pushing the most recent backup
-        p.push_most_recent_backup()
-
-        # it should be available in S3
-        response = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
-
-        # when we attempt to push a backup again
-        p.push_most_recent_backup()
-
-        # and compare the s3 responses, there should still be a single s3 item
-        # with an identical last modified timestamp
-        response2 = self.s3_client.list_objects_v2(Bucket=self.cfg['s3_bucket'])
-        response['KeyCount'].should.equal(response2['KeyCount'])
-        response['Contents'][0]['LastModified'].should.equal(response2['Contents'][0]['LastModified'])
+        # and the timestamp should be current
+        backup_meta = response['Contents'][0]
+        backup_time = p.backup_time_from_key(backup_meta['Key'])
+        backup_time.should.equal(datetime(2020, 3, 4, 2, 34, 56))


### PR DESCRIPTION
Improves the backup system, skipping trying to search for a backup directory in favor of the much simpler approach of just backing up the world directory. Requires that the server already have disabled writes to disk and flushed the current world state.

* Removes `backup` action from prospector, renamed `backup_current` to `backup`.
* Greatly expanded prospector tests.
* Ansible now installs backup script to run every 30m.

Fixes #24.