### PR TITLE
Generalize Server Invocation 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -222,12 +222,17 @@ $ ls
 FTBRevelationServer_1.0.0.zip
 $ unzip FTBRevelationServer_1.0.0.zip
 
-$ # Install the server requirements
+$ # Install the server requirements, if the pack requires it
 $ sh ./FTBInstall.sh
+
+$ # Create and populate the bootstrap script - mining camp will use this to
+$ # launch your server. Copy from _utitilies/_, and update with memory limits
+$ # and the `.jar` you're using.
+$ cp <mining-camp-checkout-dir>/utilities/server-start.sh .
 
 $ # Launch the server. You'll need to do this twice, once to create the
 $ # eula.txt and once to generate the base
-$ sh ./ServerStart.sh
+$ sh ./server-start.sh
 Missing eula.txt. Startup will fail and eula.txt will be created
 Make sure to read eula.txt before playing!
 To continue press <enter>

--- a/utilities/bootstrap.sh
+++ b/utilities/bootstrap.sh
@@ -16,7 +16,7 @@ cd $1
 session_name=minecraft
 tmux new-session -s ${session_name} -d
 pane=${session_name}:0.0
-tmux send-keys -t "$pane" 'sh ./ServerStart.sh' C-m
+tmux send-keys -t "$pane" 'sh ./server-start.sh' C-m
 
 echo "Minecraft server launched, attach to it by running:"
 echo "tmux attach-session -t ${session_name}"

--- a/utilities/server-start.sh
+++ b/utilities/server-start.sh
@@ -1,0 +1,5 @@
+# Solely responsible for bootstrapping the minecraft server
+#
+# You should modify this and bundle it into the root directory of your server
+# archive
+java -Xmx4G -Xms4G -jar minecraft_server.1.15.2.jar nogui

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -63,7 +63,7 @@ minecraft_msg () {
 # waits for it to exit.
 shutdown_server () {
     minecraft_cmd "stop"
-    pid=`pgrep -f ServerStart.sh`
+    pid=`pgrep -f server-start.sh`
     while ps -p $pid > /dev/null; do
         sleep 1
     done
@@ -81,8 +81,8 @@ mypid=$$
 if [[ "$(ps -o stat= -p $mypid)" =~ \+ ]]; then
     # Foreground, script mode
     echo "Notifying users"
-    minecraft_msg "[AWS] Warning! Server is shutting down!" "red"
-    minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
+    minecraft_msg "[MINING-CAMP] Warning! Server is shutting down!" "red"
+    minecraft_msg "[MINING-CAMP] Server going down in $DELAY seconds!" "red"
 
     # Brief delay, allowing players to finish up before shutting down
     echo "Shutting down server in $DELAY seconds"
@@ -90,7 +90,7 @@ if [[ "$(ps -o stat= -p $mypid)" =~ \+ ]]; then
     shutdown_server
 
     echo "Creating and pushing backup to S3"
-    $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup_current
+    $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
 else
     # Background, daemon mode
     echo "Running in background mode!"
@@ -112,15 +112,15 @@ else
             action=`echo $resp | jq -r '.action'`
             time=`echo $resp | jq -r '.time'`
 
-            minecraft_msg "[AWS] Warning! Spot instance terminating!" "red"
-            minecraft_msg "[AWS] Server going down in $DELAY seconds!" "red"
+            minecraft_msg "[MINING-CAMP] Warning! Spot instance terminating!" "red"
+            minecraft_msg "[MINING-CAMP] Server going down in $DELAY seconds!" "red"
 
             # Brief delay, allowing players to finish up before shutting down
             sleep $DELAY
             shutdown_server
 
             # Create and push a backup to S3
-            $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup_current
+            $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
 
             break
         fi


### PR DESCRIPTION
Server launch is now done using `server-start.sh`.

* Updated the README to indicate this should be bundled into the root of the minecraft archive and modified to fit your needs.
* Created a sample file in `utilities/server-start.sh` which can be copied across.
* Changed references from `ServerStart.sh` to `server-start.sh`.
* Fixed incorrect prospector actions in `bootstrap.sh` and  `shutdown.sh`.
* Changed "AWS" in messages sent to players to "MINING-CAMP".

Fixes #25.