### PR TITLE
Bundle utilities in with Ansible

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -228,7 +228,7 @@ $ sh ./FTBInstall.sh
 $ # Create and populate the bootstrap script - mining camp will use this to
 $ # launch your server. Copy from _utitilies/_, and update with memory limits
 $ # and the `.jar` you're using.
-$ cp <mining-camp-checkout-dir>/utilities/server-start.sh .
+$ cp <repo-checkout-directory>/utilities/server-start.sh .
 
 $ # Launch the server. You'll need to do this twice, once to create the
 $ # eula.txt and once to generate the base

--- a/ansible/bundle.yml
+++ b/ansible/bundle.yml
@@ -10,9 +10,11 @@
       state: directory
     register: tempdir
 
-  - name: "Create an archive from the local Ansible configuration"
+  - name: "Create an archive from the local Ansible configuration + utilities"
     archive:
-      path: "../ansible"
+      path: 
+      - "../ansible"
+      - "../utilities"
       dest: "{{ tempdir.path }}/ansible.tgz"
 
   - name: "Push ansible archive to S3"

--- a/ansible/bundle.yml
+++ b/ansible/bundle.yml
@@ -10,11 +10,12 @@
       state: directory
     register: tempdir
 
-  - name: "Create an archive from the local Ansible configuration + utilities"
+  - name: "Create an archive from the local Ansible + utilities"
     archive:
-      path: 
+      path:
       - "../ansible"
       - "../utilities"
+      - "../requirements.txt"
       dest: "{{ tempdir.path }}/ansible.tgz"
 
   - name: "Push ansible archive to S3"

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -101,6 +101,11 @@
       src: "files/server.properties"
       dest: "{{minecraft_dir}}/{{server_name}}/server.properties"
 
+  - name: "Install utilities"
+    copy:
+      src: "../utilities"
+      dest: "{{minecraft_dir}}/"
+
   - name: "Add periodic backup script to crontab"
     cron:
       name: "Backup creation"

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -64,11 +64,6 @@
         mount /dev/xvdb {{minecraft_dir}}
         chown ubuntu:ubuntu {{minecraft_dir}}
 
-  - name: "Clone git repo into minecraft directory"
-    git:
-      repo: https://github.com/gerhalt/mining-camp.git
-      dest: "{{minecraft_dir}}/mining-camp"
-
   - name: "Install Python requirements"
     become: true
     shell: |
@@ -110,17 +105,17 @@
     cron:
       name: "Backup creation"
       minute: "*/30"
-      job: "{{minecraft_dir}}/mining-camp/utilities/backup.sh {{minecraft_dir}}"
+      job: "{{minecraft_dir}}/utilities/backup.sh {{minecraft_dir}}"
 
   - name: "Start emergency shutdown monitoring script in the background"
     # In order to run a background process, we detach inputs and outputs and
     # use nohup. This runs shutdown.sh in its daemon mode.
     shell: |
-      nohup {{minecraft_dir}}/mining-camp/utilities/shutdown.sh {{minecraft_dir}} </dev/null >/dev/null 2>&1 &
+      nohup {{minecraft_dir}}/utilities/shutdown.sh {{minecraft_dir}} </dev/null >/dev/null 2>&1 &
 
   - name: "Fetch most recent backup from S3 and install it"
     shell: |
-      {{minecraft_dir}}/mining-camp/utilities/prospector.py fetch
+      {{minecraft_dir}}/utilities/prospector.py fetch
 
   # If using the old elastic IP method, we associate the IP with this instance
   - name: "Associate elastic IP"
@@ -143,4 +138,4 @@
 
   - name: "Start server bootstrap script"
     shell: |
-      {{minecraft_dir}}/mining-camp/utilities/bootstrap.sh {{minecraft_dir}}/{{server_name}}
+      {{minecraft_dir}}/utilities/bootstrap.sh {{minecraft_dir}}/{{server_name}}

--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -67,7 +67,7 @@
   - name: "Install Python requirements"
     become: true
     shell: |
-      pip install -r '{{minecraft_dir}}/mining-camp/requirements.txt'
+      pip install -r '../requirements.txt'
 
   - name: "Ensure server tarball doesn't exist"
     file:

--- a/ansible/stop.yml
+++ b/ansible/stop.yml
@@ -7,7 +7,7 @@
   tasks:
   - name: "Shutdown server and push backup to S3"
     shell: |
-        /minecraft/mining-camp/utilities/shutdown.sh /minecraft
+        /minecraft/utilities/shutdown.sh /minecraft
 
 - name: "Set ASG size to 0"
   hosts: localhost

--- a/utilities/backup.sh
+++ b/utilities/backup.sh
@@ -61,7 +61,7 @@ minecraft_cmd "/save-all flush"
 sleep 15
 
 # Delegate backup create and transfer to prospector
-$MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
+$MINECRAFT_ROOT/utilities/prospector.py backup
 
 # Log and notify server users
 if [ $? -eq 0 ]; then

--- a/utilities/shutdown.sh
+++ b/utilities/shutdown.sh
@@ -90,7 +90,7 @@ if [[ "$(ps -o stat= -p $mypid)" =~ \+ ]]; then
     shutdown_server
 
     echo "Creating and pushing backup to S3"
-    $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
+    $MINECRAFT_ROOT/utilities/prospector.py backup
 else
     # Background, daemon mode
     echo "Running in background mode!"
@@ -120,7 +120,7 @@ else
             shutdown_server
 
             # Create and push a backup to S3
-            $MINECRAFT_ROOT/mining-camp/utilities/prospector.py backup
+            $MINECRAFT_ROOT/utilities/prospector.py backup
 
             break
         fi


### PR DESCRIPTION
Bundles the local versions of `utilities/` and `requirements.txt` into the Ansible archive generated with the `bundle.yml` playbook. On server provision, these are used instead of checking out the mining-camp repo, like it did before. This allows testing of local changes instead of forcing merges to master.

Fixes #26.